### PR TITLE
Upgrade to Clarinet v0.31.0

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -17,4 +17,3 @@ callee_filter = false
 
 [contracts.example]
 path = "contracts/example.clar"
-depends_on = []

--- a/deps.ts
+++ b/deps.ts
@@ -1,8 +1,8 @@
-import { Account } from "https://deno.land/x/clarinet@v0.27.0/index.ts";
+import { Account } from "https://deno.land/x/clarinet@v1.0.0-beta1/index.ts";
 
-export { Chain, Clarinet, Tx, types } from "https://deno.land/x/clarinet@v0.27.0/index.ts";
+export { Chain, Clarinet, Tx, types } from "https://deno.land/x/clarinet@v1.0.0-beta1/index.ts";
 
-export type { Account } from "https://deno.land/x/clarinet@v0.27.0/index.ts";
+export type { Account } from "https://deno.land/x/clarinet@v1.0.0-beta1/index.ts";
 
 export { assertEquals } from "https://deno.land/std@0.125.0/testing/asserts.ts";
 

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -11,15 +11,11 @@ export class Context {
   constructor(preSetupTx?: Array<Tx>) {
     (Deno as any).core.ops();
 
-    var transactions: Array<Tx> = [];
-    if (preSetupTx) {
-      transactions = preSetupTx!;
-    }
-
     let result = JSON.parse(
-      (Deno as any).core.opSync("setup_chain", {
+      (Deno as any).core.opSync("api/v1/new_session", {
         name: "test",
-        transactions: transactions,
+        loadDeployment: true,
+        deploymentPath: null,
       })
     );
     this.chain = new Chain(result["session_id"]);
@@ -35,5 +31,13 @@ export class Context {
     this.deployer = this.accounts.get("deployer")!;
 
     this.models = new Models(this.chain, this.deployer);
+  }
+
+  terminate() {
+    JSON.parse(
+      (Deno as any).core.opSync("api/v1/terminate_session", {
+        sessionId: this.chain.sessionId,
+      })
+    );
   }
 }

--- a/tests/example.test-ci.ts
+++ b/tests/example.test-ci.ts
@@ -1,4 +1,5 @@
 import {
+  afterEach,
   beforeEach,
   Context,
   describe,
@@ -12,6 +13,10 @@ let ctx: Context;
 
 beforeEach(() => {
   ctx = new Context();
+});
+
+afterEach(() => {
+  ctx.terminate();
 });
 
 describe("[Contract]", () => {

--- a/tests/example.test.ts
+++ b/tests/example.test.ts
@@ -1,6 +1,7 @@
 import {
   Account,
   Accounts,
+  afterEach,
   beforeEach,
   Chain,
   Context,
@@ -21,6 +22,10 @@ beforeEach(() => {
   chain = ctx.chain;
   accounts = ctx.accounts;
   example = ctx.models.get(ExampleModel);
+});
+
+afterEach(() => {
+  ctx.terminate();
 });
 
 describe("[Example]", () => {

--- a/tests/example.test.ts
+++ b/tests/example.test.ts
@@ -10,7 +10,7 @@ import {
   run,
 } from "../deps.ts";
 import { ExampleModel } from "../models/example.model.ts";
-import fc from 'https://cdn.skypack.dev/fast-check';
+import fc from "../fast-check.ts";
 
 let ctx: Context;
 let chain: Chain;


### PR DESCRIPTION
@lnow, as @lgalabru [announced](https://discord.com/channels/621759717756370964/839633619261456444/978765801194651719) on Discord, and taking also your [discussion](https://discord.com/channels/621759717756370964/839633619261456444/978792020225196102) as reference.

Both test suites seem to run fine; concrete, and model-based ([example.test-ci.ts](https://github.com/LNow/testing-example/blob/main/tests/example.test-ci.ts)):
```bash
# concrete
$ clarinet test
# model-based
$ clarinet test tests/example.test-ci.ts
```
